### PR TITLE
[Feat] #3 - 버튼 컴포넌트 추가

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -6,6 +6,7 @@ import App from './App';
 import ChatPage from './page/main/chat/Chat';
 import HomePage from './page/main/home/Home';
 import MyPage from './page/main/mypage/Mypage';
+import BtnTest from './page/index/BtnTest';
 
 const Router = () => {
   return (
@@ -16,6 +17,7 @@ const Router = () => {
             <Route path="home" element={<HomePage />} />   
             <Route path="chat" element={<ChatPage />} />
             <Route path="mypage" element={<MyPage />} />
+            <Route path="btnTest" element={<BtnTest />} />
           </Route>
         </Routes>
       </Suspense>

--- a/src/page/component/button/Button.tsx
+++ b/src/page/component/button/Button.tsx
@@ -1,0 +1,125 @@
+import React, { ComponentProps } from 'react';
+import styled from 'styled-components'
+
+interface ButtonProps extends ComponentProps<"button"> {
+  variant?: "primary" | "secondary" | "text";
+  rightIcon?: boolean;
+  selected?: boolean;
+  children: React.ReactNode;
+}
+
+const Button = ({ 
+  variant = "primary", 
+  rightIcon = false, 
+  selected = false, 
+  ...props 
+}: ButtonProps) => {
+  return (
+    <St.Button $variant={variant} $rightIcon={rightIcon} selected={selected} {...props}>
+      {props.children}
+      {rightIcon && <Chevron/>}
+    </St.Button>
+  );
+};
+
+const Chevron = () => {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M9 18L15 12L9 6" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+export default Button;
+
+const St = {
+  Button: styled.button<{
+    $variant: ButtonProps["variant"];
+    $rightIcon: boolean;
+    selected: boolean;
+  }>`
+        display: flex;
+        align-items: center;
+        justify-content: ${props => props.$rightIcon ? "space-between" : "center"};
+
+        width: 100%;
+        padding: 1.6rem 2.4rem;
+        ${({ theme }) => theme.fonts.title_medium}
+        border-radius: 5.6rem;
+
+        &:disabled {
+          cursor: default;
+        }
+        
+        // variant별, 상태별 색상 변화
+        ${(props) => {
+          switch (props.$variant) {
+            case "primary":
+              return`
+                background-color: ${props.theme.colors.orange10};
+                color: ${props.theme.colors.white};
+                path { /* 아이콘 색상 */
+                    stroke: ${props.theme.colors.white};
+                  }
+                &:active {
+                  background-color: ${props.theme.colors.orange20};
+                }
+                &:disabled {
+                  background-color: #361E0033;
+                  color: ${props.theme.colors.gray500};
+                  path {
+                    stroke: ${props.theme.colors.gray500};
+                  }
+                }
+                ${props.selected && `
+                  background-color: ${props.theme.colors.orange30};
+                `}
+              `
+            case "secondary":
+              return`
+               background-color: ${props.theme.colors.white};
+               border: 1px ${props.theme.colors.orange70} solid;
+               color: ${props.theme.colors.gray700};
+               path { /* 아이콘 색상 */
+                    stroke: ${props.theme.colors.gray700};
+                  }
+                &:active {
+                  background-color: ${props.theme.colors.orange99};
+                }
+                &:disabled {
+                  background-color: ${props.theme.colors.gray25};
+                  border-color: ${props.theme.colors.gray400};
+                  color: ${props.theme.colors.gray400};
+                  path {
+                    stroke: ${props.theme.colors.gray400};
+                  }
+                }
+                ${props.selected && `
+                  background-color: #FFC06E66;
+                `}
+              `
+            case "text":
+              return`
+               background-color: transparent;
+               color: ${props.theme.colors.gray700};
+               path { /* 아이콘 색상 */
+                    stroke: ${props.theme.colors.gray700};
+                  }
+                &:active {
+                  background-color: ${props.theme.colors.gray100};
+                }
+                &:disabled {
+                  background-color: transparent;
+                  color: ${props.theme.colors.gray400};
+                  path {
+                    stroke: ${props.theme.colors.gray400};
+                  }
+                }
+              `
+          }
+        }}
+    `,
+  Image: styled.img`
+    height: 100%;
+  `
+}

--- a/src/page/index/BtnTest.tsx
+++ b/src/page/index/BtnTest.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import Button from '../component/button/Button';
+
+const Index = () => {
+  return (
+    <St.BtnTestWrapper>
+      <St.HomeTitle>테스트</St.HomeTitle>
+      <Button >확인</Button>
+      <Button rightIcon >확인</Button>
+      <Button rightIcon selected >확인</Button>
+      <Button rightIcon disabled >확인</Button>
+      <Button variant='secondary'>확인</Button>
+      <Button variant='secondary' rightIcon >확인</Button>
+      <Button variant='secondary' rightIcon selected >확인</Button>
+      <Button variant='secondary' rightIcon disabled >확인</Button>
+      <Button variant='text'>확인</Button>
+      <Button variant='text' rightIcon >확인</Button>
+      <Button variant='text' rightIcon selected >확인</Button>
+      <Button variant='text' rightIcon disabled >확인</Button>
+    </St.BtnTestWrapper>
+  );
+};
+
+export default Index;
+
+const St = {
+  BtnTestWrapper: styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 2rem;
+
+    width: 30rem;
+    padding: 5rem;
+  `,
+  HomeTitle: styled.h1`
+    ${({ theme }) => theme.fonts.display_medium};
+  `,
+};


### PR DESCRIPTION
## 🍦 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 재사용 가능한 버튼 컴포넌트를 추가했습니다.
- 각 속성별 버튼 모양을 확인할 수 있는 /btnTest 페이지를 임시로 추가해두었습니다.

## 💭 PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- - 디자인안의 Type은 variant 속성으로 지정할 수 있습니다. (`primary | secondary | text`)
- 디자인안의 State 중 'Disabled'와 'Selected'는 disabled, selected 프로퍼티를 추가하면 됩니다. 'Pressed'는 사용자가 클릭할 때 보입니다.
- styled component의 prop 이름은 $ prefix를 넣어주는게 안전한 것으로 보입니다

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| /btnTest | <img src = "https://github.com/user-attachments/assets/19174773-ea09-4e64-a506-11923ea4e771" width ="250">|

## 🌈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #3 
